### PR TITLE
Add the ability to specify additional logging functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ useful in instances where there are types or struct fields that are known to be 
 does not have the ability to modify the code to add the struct tags or comment-based annotations necessary to mark them
 directly.
 
+The check can also be configured to verify that the argument passed to a function at a particular index is a
+compile-time constant by specifying the function and parameter index in the "ConstMessageLoggingFunctions"
+configuration.
+
 When run as a standalone program, the configuration is specified as JSON and provided using a flag.
 
 The configuration is defined in the [safelogging/config.go] file as follows:
@@ -55,22 +59,28 @@ type Config struct {
 	// The safety value in this map can make a type less safe, but not more safe (for example, if a struct type is
 	// determined to be unsafe based on its fields, marking it as safe using this configuration will not make it safe).
 	// The values in this map are applied on top of the default.
-	TypeLogSafety *map[string]LogSafetyType `json:"typeLogSafety,omitempty" yaml:"type-log-safety,omitempty"`
+	TypeLogSafety *map[string]LogSafetyType `json:"typeLogSafety,omitempty" mapstructure:"type-log-safety,omitempty"`
 
-    // If true, omits the default TypeLogSafety values and uses only those specified in the TypeLogSafety map.
-    TypeLogSafetyOmitDefaults bool `json:"typeLogSafetyDisableDefaults,omitempty" yaml:"type-log-safety-disable-defaults,omitempty"`
+	// If true, omits the default TypeLogSafety values and uses only those specified in the TypeLogSafety map.
+	TypeLogSafetyOmitDefaults bool `json:"typeLogSafetyDisableDefaults,omitempty" mapstructure:"type-log-safety-disable-defaults,omitempty"`
 
 	// StructFieldLogSafety is a map from fully qualified struct field identifier to the log safety for that field. The
 	// type safety for a struct is the "least safe" of all of its types/fields (recursively) and any markings or safety
 	// configured for the struct itself.
-	StructFieldLogSafety *map[string]LogSafetyType `json:"structFieldLogSafety,omitempty" yaml:"struct-field-log-safety,omitempty"`
-	
+	StructFieldLogSafety *map[string]LogSafetyType `json:"structFieldLogSafety,omitempty" mapstructure:"struct-field-log-safety,omitempty"`
+
 	// If true, omits the default StructFieldLogSafety values and uses only those specified in the StructFieldLogSafety map.
-    StructFieldLogSafetyOmitDefaults bool `json:"structFieldLogSafetyDisableDefaults,omitempty" yaml:"struct-field-log-safety-disable-defaults,omitempty"`
+	StructFieldLogSafetyOmitDefaults bool `json:"structFieldLogSafetyDisableDefaults,omitempty" mapstructure:"struct-field-log-safety-disable-defaults,omitempty"`
+
+	// ConstMessageLoggingFunctions is a list of functions are checked to ensure that the parameter at a specified index
+	// is a constant string. Currently, the check only supports checking one parameter per function -- if the provided
+	// slice contains the same function multiple times, the last entry will take precedence. This configuration can add
+	// to the default set of functions, but cannot override them.
+	ConstMessageLoggingFunctions []ConstMessageLoggingFunction `json:"constMessageLoggingFunctions,omitempty" mapstructure:"const-message-logging-functions,omitempty"`
 }
 ```
 
-If configuration is not provided, then the following defaults are used:
+If configuration is not provided, then the following defaults are used for type safety:
 
 ```
 func builtinTypeSafetyMap() map[string]LogSafetyType {
@@ -94,6 +104,17 @@ func builtinStructFieldSafetyMap() map[string]LogSafetyType {
 		"github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient.ClientConfig.APIToken": LogSafetyTypeDoNotLog,
 	}
 }
+```
+
+The first parameter (the one at index 0) for the following functions are always checked to ensure that they are
+compile-time constants (configuration can be used to check parameters for additional functions, but the check for these
+functions cannot be overridden):
+
+```
+func (github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log.Logger).Debug(msg string, params ...github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log.Param)
+func (github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log.Logger).Info(msg string, params ...github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log.Param)
+func (github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log.Logger).Warn(msg string, params ...github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log.Param)
+func (github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log.Logger).Error(msg string, params ...github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log.Param)
 ```
 
 ## Manually suppressing check errors
@@ -154,9 +175,13 @@ The following functions are considered logging functions:
 * `github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log.Logger.Warn(msg string, params ...github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log.Param)`
 * `github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log.Logger.Error(msg string, params ...github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log.Param)`
 
-The check verifies that the "msg" parameter is a value that is known at compile-time. Generally, this means that it is
-either a string literal (`logger.Info("Message")`), a reference to a string constant (`const msg = "Message"; logger.Info(msg)`),
-or a concatenation of either (`const msg = "Message"; logger.Info(msg + " content")`).
+The check verifies that the first parameter (the one at index 0) is a value that is known at compile-time. Generally,
+this means that it is  either a string literal (`logger.Info("Message")`), a reference to a string constant
+(`const msg = "Message"; logger.Info(msg)`), or a concatenation of either
+(`const msg = "Message"; logger.Info(msg + " content")`).
+
+The check can be configured to verify this property for additional functions (the user must specify the identifier of
+the function and the index of the parameter that should be checked as part of the analyzer configuration).
 
 The analyzer only checks the above -- in particular, it does not perform code analysis to determine usage patterns that
 semantically result in a constant output. For example, code such as `func msg() string { return "Message" }; logger.Info(msg())`,

--- a/golangcilint/safelogging/plugin.go
+++ b/golangcilint/safelogging/plugin.go
@@ -27,28 +27,12 @@ func init() {
 	register.Plugin("safelogging", New)
 }
 
-type Settings struct {
-	// TypeLogSafety is a map from fully qualified type name identifier to the log safety for that type.
-	// The safety value in this map can make a type less safe, but not more safe (for example, if a struct type is
-	// determined to be unsafe based on its fields, marking it as safe using this configuration will not make it safe).
-	//
-	// If the value is nil, uses a set of preconfigured defaults. If the value is present but empty, uses none.
-	TypeLogSafety *map[string]safelogging.LogSafetyType `json:"typeLogSafety,omitempty"`
-
-	// StructFieldLogSafety is a map from fully qualified struct field identifier to the log safety for that field. The
-	// type safety for a struct is the "least safe" of all of its types/fields (recursively) and any markings or safety
-	// configured for the struct itself.
-	//
-	// If the value is nil, uses a set of preconfigured defaults. If the value is present but empty, uses none.
-	StructFieldLogSafety *map[string]safelogging.LogSafetyType `json:"structFieldLogSafety,omitempty"`
-}
-
 type Plugin struct {
 	configJSONBytes []byte
 }
 
 func New(settings any) (register.LinterPlugin, error) {
-	s, err := register.DecodeSettings[Settings](settings)
+	s, err := register.DecodeSettings[safelogging.Config](settings)
 	if err != nil {
 		return nil, err
 	}

--- a/safelogging/analyzer_test.go
+++ b/safelogging/analyzer_test.go
@@ -52,12 +52,19 @@ func TestAnalyzerWithConfig(t *testing.T) {
 			"safe-logging-go/safeloggingtests/config/config_a.TestStructWithFieldSafetySetViaConfig.FieldToMarkUnsafe":   LogSafetyTypeUnsafe,
 			"safe-logging-go/safeloggingtests/config/config_a.TestStructWithFieldSafetySetViaConfig.FieldToMarkDoNotLog": LogSafetyTypeDoNotLog,
 		},
+		ConstMessageLoggingFunctions: []ConstMessageLoggingFunction{
+			{
+				Function:          "func safe-logging-go/safeloggingtests/config/config_d.CustomLoggingFunction(priority int, msg string, args ...any)",
+				MessageParamIndex: 1,
+			},
+		},
 	})
 	require.NoError(t, err)
 	err = analyzer.Analyzer().Flags.Set("json-config", string(cfgBytes))
 	require.NoError(t, err)
 	analysistest.Run(t, analysistest.TestData(), analyzer.Analyzer(),
 		"safe-logging-go/safeloggingtests/config/config_a",
+		"safe-logging-go/safeloggingtests/config/config_d",
 	)
 }
 

--- a/safelogging/config.go
+++ b/safelogging/config.go
@@ -23,18 +23,29 @@ type Config struct {
 	// The safety value in this map can make a type less safe, but not more safe (for example, if a struct type is
 	// determined to be unsafe based on its fields, marking it as safe using this configuration will not make it safe).
 	// The values in this map are applied on top of the default.
-	TypeLogSafety *map[string]LogSafetyType `json:"typeLogSafety,omitempty" yaml:"type-log-safety,omitempty"`
+	TypeLogSafety *map[string]LogSafetyType `json:"typeLogSafety,omitempty" mapstructure:"type-log-safety,omitempty"`
 
 	// If true, omits the default TypeLogSafety values and uses only those specified in the TypeLogSafety map.
-	TypeLogSafetyOmitDefaults bool `json:"typeLogSafetyDisableDefaults,omitempty" yaml:"type-log-safety-disable-defaults,omitempty"`
+	TypeLogSafetyOmitDefaults bool `json:"typeLogSafetyDisableDefaults,omitempty" mapstructure:"type-log-safety-disable-defaults,omitempty"`
 
 	// StructFieldLogSafety is a map from fully qualified struct field identifier to the log safety for that field. The
 	// type safety for a struct is the "least safe" of all of its types/fields (recursively) and any markings or safety
 	// configured for the struct itself.
-	StructFieldLogSafety *map[string]LogSafetyType `json:"structFieldLogSafety,omitempty" yaml:"struct-field-log-safety,omitempty"`
+	StructFieldLogSafety *map[string]LogSafetyType `json:"structFieldLogSafety,omitempty" mapstructure:"struct-field-log-safety,omitempty"`
 
 	// If true, omits the default StructFieldLogSafety values and uses only those specified in the StructFieldLogSafety map.
-	StructFieldLogSafetyOmitDefaults bool `json:"structFieldLogSafetyDisableDefaults,omitempty" yaml:"struct-field-log-safety-disable-defaults,omitempty"`
+	StructFieldLogSafetyOmitDefaults bool `json:"structFieldLogSafetyDisableDefaults,omitempty" mapstructure:"struct-field-log-safety-disable-defaults,omitempty"`
+
+	// ConstMessageLoggingFunctions is a list of functions are checked to ensure that the parameter at a specified index
+	// is a constant string. Currently, the check only supports checking one parameter per function -- if the provided
+	// slice contains the same function multiple times, the last entry will take precedence. This configuration can add
+	// to the default set of functions, but cannot override them.
+	ConstMessageLoggingFunctions []ConstMessageLoggingFunction `json:"constMessageLoggingFunctions,omitempty" mapstructure:"const-message-logging-functions,omitempty"`
+}
+
+type ConstMessageLoggingFunction struct {
+	Function          FuncRef `json:"function" mapstructure:"function"`
+	MessageParamIndex int     `json:"messageParamIndex" mapstructure:"message-param-index"`
 }
 
 func (c *Config) ToParam() Param {
@@ -58,6 +69,12 @@ func (c *Config) ToParam() Param {
 	}
 	p.structFieldSafetyMap = structFieldSafetyMap
 
+	constMessageLoggingFunctions := make(map[FuncRef]int)
+	for _, fn := range c.ConstMessageLoggingFunctions {
+		constMessageLoggingFunctions[fn.Function] = fn.MessageParamIndex
+	}
+	p.constMessageLoggingFunctions = constMessageLoggingFunctions
+
 	return p
 }
 
@@ -67,6 +84,11 @@ type Param struct {
 
 	// map from fully qualified struct field identifier to log safety for that field
 	structFieldSafetyMap map[string]LogSafetyType
+
+	// map from function reference to the index of the parameter that should be a constant message string. Any keys
+	// that match builtin configuration will not have any effect (the builtin configuration can be added to, but not
+	// overridden).
+	constMessageLoggingFunctions map[FuncRef]int
 }
 
 func builtinTypeSafetyMap() map[string]LogSafetyType {

--- a/safelogging/safelogging_findcalls.go
+++ b/safelogging/safelogging_findcalls.go
@@ -64,8 +64,8 @@ type FuncRefHandler func(
 	param Param,
 )
 
-func getFuncRefHandlers() map[FuncRef]FuncRefHandler {
-	return map[FuncRef]FuncRefHandler{
+func getFuncRefHandlers(compileTimeConstantArgFuncRefs map[FuncRef]int) map[FuncRef]FuncRefHandler {
+	handlers := map[FuncRef]FuncRefHandler{
 		svc1logSafeParam:    checkSingleParamThatIsSecondArgToFuncIsSafeToLog(LogSafetyTypeSafe),
 		svc1logSafeParams:   checkSingleParamThatIsFirstArgToFuncIsSafeToLog(LogSafetyTypeSafe),
 		svc1logUnsafeParam:  checkSingleParamThatIsSecondArgToFuncIsSafeToLog(LogSafetyTypeUnsafe),
@@ -85,6 +85,14 @@ func getFuncRefHandlers() map[FuncRef]FuncRefHandler {
 		svc1logWarn:  checkFirstArgIsCompileTimeConstant,
 		svc1logError: checkFirstArgIsCompileTimeConstant,
 	}
+	for k, v := range compileTimeConstantArgFuncRefs {
+		// do not allow overriding of built-in handlers
+		if _, ok := handlers[k]; ok {
+			continue
+		}
+		handlers[k] = checkArgAtIndexIsCompileTimeConstant(v)
+	}
+	return handlers
 }
 
 func checkSingleParamThatIsFirstArgToFuncIsSafeToLog(permittedSafetyLevel LogSafetyType) FuncRefHandler {
@@ -169,31 +177,40 @@ func checkParamsAtArgIdxToFuncIsSafeToLog(argIdxToSafetyLevel map[int]LogSafetyT
 	}
 }
 
-func checkFirstArgIsCompileTimeConstant(
-	_ FuncRef,
-	id *ast.Ident,
-	call *ast.CallExpr,
-	pass *analysis.Pass,
-	_ *logSafetyInfoBundle,
-	_ map[types.Type]*ast.Ident,
-	_ *CommentBasedLogSafetyTracker,
-	fileCommentRetriever filecomments.Retriever,
-	_ Param,
-) {
-	if argIsCompileTimeConstant := checkExpressionIsCompileTimeConstant(call.Args[0], id, call, pass); argIsCompileTimeConstant {
-		return
+func checkArgAtIndexIsCompileTimeConstant(idx int) FuncRefHandler {
+	return func(
+		_ FuncRef,
+		id *ast.Ident,
+		call *ast.CallExpr,
+		pass *analysis.Pass,
+		_ *logSafetyInfoBundle,
+		_ map[types.Type]*ast.Ident,
+		_ *CommentBasedLogSafetyTracker,
+		fileCommentRetriever filecomments.Retriever,
+		_ Param,
+	) {
+		// if argument index is out of range, do not report issue
+		if idx >= len(call.Args) {
+			return
+		}
+
+		if argIsCompileTimeConstant := checkExpressionIsCompileTimeConstant(call.Args[idx], id, call, pass); argIsCompileTimeConstant {
+			return
+		}
+		if nodeHasSuppressWarningsComment(id.Pos(), fileCommentRetriever) {
+			return
+		}
+		pass.Report(analysis.Diagnostic{
+			Pos: call.Pos(),
+			Message: fmt.Sprintf(
+				"%s called with unsafe argument: message must be a compile-time constant",
+				id.Name,
+			),
+		})
 	}
-	if nodeHasSuppressWarningsComment(id.Pos(), fileCommentRetriever) {
-		return
-	}
-	pass.Report(analysis.Diagnostic{
-		Pos: call.Pos(),
-		Message: fmt.Sprintf(
-			"%s called with unsafe argument: message must be a compile-time constant",
-			id.Name,
-		),
-	})
 }
+
+var checkFirstArgIsCompileTimeConstant = checkArgAtIndexIsCompileTimeConstant(0)
 
 func checkExpressionIsCompileTimeConstant(expr ast.Expr, id *ast.Ident, call *ast.CallExpr, pass *analysis.Pass) bool {
 	switch exprVal := expr.(type) {
@@ -540,7 +557,7 @@ func findLogCalls(
 	fileCommentRetriever filecomments.Retriever,
 	param Param,
 ) {
-	funcRefHandlers := getFuncRefHandlers()
+	funcRefHandlers := getFuncRefHandlers(param.constMessageLoggingFunctions)
 
 	// Return a mapping from *ast.Ident to FuncRef for all relevant functions.
 	// The calls to these functions are what will be analyzed for the check.

--- a/safelogging/testdata/config/config_d/safelogging_config_d.go
+++ b/safelogging/testdata/config/config_d/safelogging_config_d.go
@@ -1,0 +1,17 @@
+package config_d
+
+import (
+	"fmt"
+	"time"
+)
+
+func CustomLoggingFunction(priority int, msg string, args ...any) {
+	fmt.Printf("%d: %s - %v\n", priority, msg, args)
+}
+
+func ParamTests() {
+	CustomLoggingFunction(1, "String constant", "safe")
+
+	msg := fmt.Sprintf("%v", time.Now())
+	CustomLoggingFunction(1, msg, "unsafe") // want `CustomLoggingFunction called with unsafe argument: message must be a compile-time constant`
+}


### PR DESCRIPTION


## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Adds the ability to specify additional logging functions beyond the svclog.Logger functions that should be checked to ensure that a parameter at a particular position is a compile-time constant using configuration.

This allows for more safetly supporting the pattern where a project may define a custom logging function that wraps an svc1log logger: in this scenario, the svc1log call in the wrapper function can be marked as allowed and then the wrapper function can be added to the check to ensure that code that calls the wrapper function uses compile-time constants. Also allows for performing this check on arbitrary functions that are not directly related to svc1log.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

